### PR TITLE
Fix typo in Building on Ethereum/Intro to Solidity

### DIFF
--- a/curriculum/en/2-building-on-ethereum/2-intro-to-solidity.md
+++ b/curriculum/en/2-building-on-ethereum/2-intro-to-solidity.md
@@ -56,7 +56,7 @@ function functionName(uint x, uint y) public view returns (uint){
 }
 ```
 
-Every function must begin with the keyword `function`, followed by its name `functionName`. Whatever is placed inside the brackets (parameters) are the inputs, or the values that you will pass to your function. `Public view returns` states the visibility of the function. In this case, it defines that can it be accessible to the other contracts, denoted by the keyword `public`. The function promises not to modify the state of the blockchain, denoted by the word `view`. Finally, `returns` defines that the function will return a value, and also defines the data type of that output.
+Every function must begin with the keyword `function`, followed by its name `functionName`. Whatever is placed inside the brackets (parameters) are the inputs, or the values that you will pass to your function. `Public view returns` states the visibility of the function. In this case, it defines that it can be accessible to the other contracts, denoted by the keyword `public`. The function promises not to modify the state of the blockchain, denoted by the word `view`. Finally, `returns` defines that the function will return a value, and also defines the data type of that output.
 
 ## Try It Yourself
 


### PR DESCRIPTION
When going through the `/en/curriculum/2-building-on-ethereum/2-intro-to-solidity` page of the curriculum, I noticed a typo around the `Anatomy of A Function` section. This PR fixes it 😄 