### PR TITLE
Infura project id renamed to api key

### DIFF
--- a/curriculum/en/6-building-your-frontend/0-setup.md
+++ b/curriculum/en/6-building-your-frontend/0-setup.md
@@ -11,7 +11,7 @@ tweet: "Build a frontend for a full-stack dapp with #30DaysofWeb3 @womenbuildweb
 
 In this lesson, we will build a frontend for our dapp using React, Next.js, ethers.js, Rainbowkit, Web3.Storage, and The Graph. Our app will work with Coinbase Wallet or other user-controlled wallets like MetaMask, Rainbow, and WalletConnect. Users will be able to connect their wallet and interact with our smart contract so they can create new events, RSVP to events, and confirm attendees.
 
-In the next few sections, we will work on enabling users to create new events. First, we will set up RainbowKit to support an intuitive muli-wallet experience in our app. Next, we will integrate Web3.Storage to store some event data off-chain, or off the blockchain. Then we will import and use ethers.js to interact with our deployed smart contract. Finally, we will brush up our frontend to call our smart contract's `createNewEvent` function and handle successful or failed ransactions.
+In the next few sections, we will work on enabling users to create new events. First, we will set up RainbowKit to support an intuitive muli-wallet experience in our app. Next, we will integrate Web3.Storage to store some event data off-chain, or off the blockchain. Then we will import and use ethers.js to interact with our deployed smart contract. Finally, we will brush up our frontend to call our smart contract's `createNewEvent` function and handle successful or failed transactions.
 
 > Note: To make it easy for you, please create a new repo/project folder for this section. However, if you feel you are comfortable enough, you can choose to use [mono repos](https://blog.logrocket.com/managing-full-stack-monorepo-pnpm/)
 

--- a/curriculum/en/6-building-your-frontend/1-intro-to-rainbowkit.md
+++ b/curriculum/en/6-building-your-frontend/1-intro-to-rainbowkit.md
@@ -19,7 +19,7 @@ At the root of your project, create a new file called `.env.local`. In the web3r
 
 While you're in this file, you can also replace `<Your Infura project id>` with your Infura project id. You can find that by going to your Infura dashboard and selecting your project settings.
 
-> Note: [Infura has renamed project id to API Key](https://docs.infura.io/infura/networks/ethereum/how-to/secure-a-project/project-id) - you will no longer see project id in your project settings. Select the API Key found under the endpoints tab of your project settings!
+> Note: Infura has renamed project id to API Key [see more here](https://docs.infura.io/infura/networks/ethereum/how-to/secure-a-project/project-id) - you will no longer see project id in your project settings. Select the API Key found under the endpoints tab of your project settings!
 
 ## Importing and Configuration of Chains
 

--- a/curriculum/en/6-building-your-frontend/1-intro-to-rainbowkit.md
+++ b/curriculum/en/6-building-your-frontend/1-intro-to-rainbowkit.md
@@ -19,7 +19,7 @@ At the root of your project, create a new file called `.env.local`. In the web3r
 
 While you're in this file, you can also replace `<Your Infura project id>` with your Infura project id. You can find that by going to your Infura dashboard and selecting your project settings.
 
-> Note: Infura has renamed project id to API Key [see more here](https://docs.infura.io/infura/networks/ethereum/how-to/secure-a-project/project-id) - you will no longer see project id in your project settings. Select the API Key found under the endpoints tab of your project settings!
+> Note: Infura has renamed project id to API Key. [see more here](https://docs.infura.io/infura/networks/ethereum/how-to/secure-a-project/project-id) - you will no longer see project id in your project settings. Select the API Key found under the endpoints tab of your project settings!
 
 ## Importing and Configuration of Chains
 

--- a/curriculum/en/6-building-your-frontend/1-intro-to-rainbowkit.md
+++ b/curriculum/en/6-building-your-frontend/1-intro-to-rainbowkit.md
@@ -19,6 +19,8 @@ At the root of your project, create a new file called `.env.local`. In the web3r
 
 While you're in this file, you can also replace `<Your Infura project id>` with your Infura project id. You can find that by going to your Infura dashboard and selecting your project settings.
 
+> Note: [Infura has renamed project id to API Key](https://docs.infura.io/infura/networks/ethereum/how-to/secure-a-project/project-id) - you will no longer see project id in your project settings. Select the API Key found under the endpoints tab of your project settings!
+
 ## Importing and Configuration of Chains
 
 We can configure RainbowKit in our `_app.js` file (located in the `pages` folder of the project). To configure chains, as well as the connectors that are required, a wagmi client has to be set up. You are free to use as many chains as you wish but in our dApp, we used Polygon chain since we deployed on the Polygon testnet (Mumbai).


### PR DESCRIPTION
added a note under intro to rainbow-kit in section 6 indicating that Infura renamed project id to API key so that learners don't look for a non-existent property called project id in their Infura project settings