### PR TITLE
RSVP object id fix in Graph

### DIFF
--- a/curriculum/en/5-creating-your-subgraph/5-mappings.md
+++ b/curriculum/en/5-creating-your-subgraph/5-mappings.md
@@ -197,11 +197,12 @@ function getOrCreateAccount(address: Address): Account {
 }
 
 export function handleNewRSVP(event: NewRSVP): void {
-  let newRSVP = RSVP.load(event.transaction.from.toHex());
+  let id = event.params.eventID.toHex() + event.params.attendeeAddress.toHex();
+  let newRSVP = RSVP.load(id);
   let account = getOrCreateAccount(event.params.attendeeAddress);
   let thisEvent = Event.load(event.params.eventID.toHex());
   if (newRSVP == null && thisEvent != null) {
-    newRSVP = new RSVP(event.transaction.from.toHex());
+    newRSVP = new RSVP(id);
     newRSVP.attendee = account.id;
     newRSVP.event = thisEvent.id;
     newRSVP.save();


### PR DESCRIPTION
Currently the id for the RSVP object created is just the address of the sender of the transaction which is not unique and causes a bug where only one RSVP can be made on the app by any wallet.

Explained [here](https://discord.com/channels/970892422487900191/989056491719892992/1005894222303461601) on discord.