### PR TITLE
Use version 0.6.1 of rad cli in section 9 intro tp radicle

### DIFF
--- a/curriculum/en/9-wrapping-up/2-intro-to-radicle.md
+++ b/curriculum/en/9-wrapping-up/2-intro-to-radicle.md
@@ -47,7 +47,7 @@ sudo "/Applications/CMake.app/Contents/bin/cmake-gui" --install
 Now you can run the command below to finally install the Radicle CLI. This might take a few minutes.
 
 ```
-cargo install --force --locked --git https://seed.alt-clients.radicle.xyz/radicle-cli.git radicle-cli
+cargo install radicle-cli --force --locked --git https://github.com/radicle-dev/radicle-cli.git --tag v0.6.1
 ```
 
 Run `rad` to test if the installation succeeded. You should see the info below:


### PR DESCRIPTION
Currently when using the lates version of the rad cli users can run into issues where there repo is not actually published to rad...

https://discord.com/channels/970892422487900191/999393790446014587/1015272888955306094

After taking a look in the rad discord, the maintainers look to be recommending using version 0.6.1 since the latest version of rad is not quite ready to use...

https://discord.com/channels/841318878125490186/841342872082579466/1008980140413431860

https://discord.com/channels/841318878125490186/841342872082579466/1009479448283852880

This change updates the intro to radicle page of section 9 to make sure the command that installs the radicle cli installs version 0.6.1.