### PR TITLE
fix(section 3)

### DIFF
--- a/curriculum/en/3-writing-your-smart-contract/5-writing-a-test-script.md
+++ b/curriculum/en/3-writing-your-smart-contract/5-writing-a-test-script.md
@@ -34,7 +34,7 @@ Inside our `main` function, we can use hardhat to deploy the contract locally by
 ```javascript
 const rsvpContractFactory = await hre.ethers.getContractFactory("Web3RSVP");
 const rsvpContract = await rsvpContractFactory.deploy();
-await rsvpContract.deployed();
+await rsvpContract.waitForDeployment();
 console.log("Contract deployed to:", rsvpContract.address);
 ```
 


### PR DESCRIPTION
Looks like `deployed` deosn't work anymore? I couldn't find documentation about it, but I could find a usage of `waitForDeployment`: https://hardhat.org/hardhat-runner/docs/guides/deploying#:~:text=await%20lock.waitForDeployment()%3B

When I run locally locally I get this error if I use `deployed`:
<img width="659" alt="image" src="https://github.com/womenbuildweb3/30daysofweb3.xyz/assets/22522889/91e349c7-9580-4b12-a5fb-1c3489586746">